### PR TITLE
flip the paren/brackets to make markdown link work

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Genentech
 September 21-22, 2015
 
 
-Workshop website: (http://datacarpentry.github.io/2015-09-21-Genentech/)[http://datacarpentry.github.io/2015-09-21-Genentech/]
+Workshop website: [http://datacarpentry.github.io/2015-09-21-Genentech/](http://datacarpentry.github.io/2015-09-21-Genentech/)
 
 
 


### PR DESCRIPTION
link was off as parens flipped
